### PR TITLE
fix: Ensure ModalDialogs do not hang on escape presses due to no return.

### DIFF
--- a/textology/widgets/_modal_dialog.py
+++ b/textology/widgets/_modal_dialog.py
@@ -18,7 +18,7 @@ class ModalDialog(ModalScreen):
     """Basic modal screen to show a provided widget and add basic navigation."""
 
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("escape", "dismiss()", show=False),
+        Binding("escape", "dismiss(None)", show=False),
     ]
     DEFAULT_CSS = """
     ModalDialog {


### PR DESCRIPTION
## Contributor Checklist

Please confirm the following:

- [x] I have run tests locally, and they all pass.
- [x] I have added or extended tests, to cover any new features or changes included in this PR.
- [x] I have added or updated documentation, to cover any new features or changes included in this PR.
- [x] I have followed the [Contributing Guide](/pyranha-labs/textology/blob/main/CONTRIBUTING.md) to ensure code quality to the best of my ability.
- [x] I have self-reviewed my PR to ensure the guidelines have been followed to the best of my ability.
