### PR TITLE
chg: Replace deprecated utcnow call in pytest utilities to improve python3.12 support.

### DIFF
--- a/textology/pytest_utils.py
+++ b/textology/pytest_utils.py
@@ -8,6 +8,7 @@ import sqlite3
 import time
 from dataclasses import dataclass
 from datetime import datetime
+from datetime import timezone
 from os import PathLike
 from pathlib import Path
 from types import ModuleType
@@ -409,7 +410,7 @@ def pytest_sessionfinish(
 
     if failures:
         final_result = {
-            "timestamp": str(datetime.utcnow()),
+            "timestamp": datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f"),
             "exitstatus": exitstatus,
             "environment": {
                 "cpus": os.cpu_count(),


### PR DESCRIPTION
## Contributor Checklist

Please confirm the following:

- [x] I have run tests locally, and they all pass.
- [x] I have added or extended tests, to cover any new features or changes included in this PR.
- [x] I have added or updated documentation, to cover any new features or changes included in this PR.
- [x] I have followed the [Contributing Guide](/pyranha-labs/textology/blob/main/CONTRIBUTING.md) to ensure code quality to the best of my ability.
- [x] I have self-reviewed my PR to ensure the guidelines have been followed to the best of my ability.
